### PR TITLE
Use buffer ring at ground and in tower mode

### DIFF
--- a/chimera-hydra.el
+++ b/chimera-hydra.el
@@ -38,6 +38,11 @@
 If no VALUE is provided, this clears the flag."
   (hydra-set-property hydra flag value))
 
+(defun chimera-hydra-is-active-p (name)
+  "Check whether the hydra named NAME is active."
+  (let ((hydra-keymap (symbol-value (intern (concat "hydra-" name "/keymap")))))
+    (eq hydra-curr-map hydra-keymap)))
+
 (defun chimera-hydra-portend-exit (mode &optional value)
   "Set a mode exit flag to indicate cleanup operations need to be performed."
   (let* ((mode-name (chimera-mode-name mode))

--- a/rigpa-buffer-mode.el
+++ b/rigpa-buffer-mode.el
@@ -180,10 +180,8 @@ re-insert (i.e. \"break insert\") the exit buffer at that position."
                  (buffer-list)))))
 
 (defun rigpa-buffer-create-ring ()
-  "Create the buffer ring upon entry into buffer mode."
+  "Create or update the buffer ring upon entry into buffer mode."
   (interactive)
-  ;; delete buffer ring and rebuild from scratch each time, for now,
-  ;; instead of maintaining a persistent buffer ring via hooks
   (let* ((ring-name (if (eq rigpa--complex rigpa-meta-tower-complex)
                         "2"
                       "0")) ; TODO: derive from coordinates later

--- a/rigpa-buffer-mode.el
+++ b/rigpa-buffer-mode.el
@@ -246,7 +246,7 @@ current ('original') buffer."
   ("s" rigpa-buffer-search "search" :exit t)
   ("/" rigpa-buffer-search "search" :exit t)
   ("i" ibuffer "list (ibuffer)" :exit t)
-  ("x" kill-buffer "delete")
+  ("x" kill-buffer "delete" :exit t)
   ("?" rigpa-buffer-info "info" :exit t)
   ("q" rigpa-buffer-return-to-original "return to original" :exit t)
   ("H-m" rigpa-toggle-menu "show/hide this menu")

--- a/rigpa-buffer-mode.el
+++ b/rigpa-buffer-mode.el
@@ -34,6 +34,8 @@
 (require 'chimera)
 (require 'chimera-hydra)
 (require 's)
+(require 'dynaring)
+(require 'buffer-ring)
 
 (defconst rigpa-buffer-ring-name-prefix "rigpa-buffer-ring")
 

--- a/rigpa-buffer-mode.el
+++ b/rigpa-buffer-mode.el
@@ -209,19 +209,6 @@ current ('original') buffer."
   (rigpa-buffer-return-to-original)
   (ivy-switch-buffer))
 
-;; TODO: implement a dynamic ring buffer storing every visited buffer
-;; then, buffer mode retains a pointer to the current position (buffer)
-;; and reverses direction of traversal each time buffer mode is exited
-;; h and l should then use this wrapped form of previous and next buffer
-;; we also wouldn't need to rely on evil-switch-to-windows-last-buffer
-;; so there would be no need to "flash back"
-;; this should be an independent utility library so that it can be used
-;; in all modes that need an intuitive way to keep track of recency
-;; maybe `recency-ring`, has a nice... ring to it
-
-;; See the existing packages "dynamic-ring" and "buffer-ring" that
-;; probably do this very thing. But in this case it may be better to
-;; simply use (buffer-list) directly which appears to keep track of recency
 (defhydra hydra-buffer (:columns 3
                         :body-pre (progn (rigpa-buffer--setup-buffer-marks-table)
                                          (chimera-hydra-signal-entry chimera-buffer-mode)

--- a/rigpa-buffer-mode.el
+++ b/rigpa-buffer-mode.el
@@ -37,6 +37,15 @@
 
 (defconst rigpa-buffer-ring-name-prefix "rigpa-buffer-ring")
 
+(defgroup rigpa-buffer nil
+  "Rigpa buffer mode."
+  :group 'rigpa)
+
+(defcustom rigpa-buffer-ignore-buffers nil
+  "Buffers to ignore in navigation."
+  :type 'list
+  :group 'rigpa-buffer)
+
 (evil-define-state buffer
   "Buffer state."
   :tag " <B> "
@@ -136,54 +145,80 @@ buffer mode."
       (switch-to-buffer (rigpa-buffer-original-buffer))
     (error (message "Buffer no longer exists!"))))
 
-(defun rigpa-buffer-flash-to-original ()
-  "Go momentarily to original buffer and return.
+(defun rigpa-buffer-link-to-original ()
+  "Reinsert the exit buffer near the original head of the ring.
 
-This 'flash' allows the original buffer, rather than the previous one
-encountered while navigating to the present one, to be treated as the
-last buffer for 'flashback' ('Alt-tab') purposes. The flash should
-happen quickly enough not to be noticeable."
+When we exit buffer mode, the buffer we exit into should be considered
+proximate to the original buffer upon entry into buffer mode, not to
+the buffers encountered in transit to this buffer. To retain this notion
+of recency, we rotate the ring back to the original orientation and then
+re-insert (i.e. \"break insert\") the exit buffer at that position."
   (interactive)
-  (unless (equal (current-buffer) (rigpa-buffer-original-buffer))
-    (let ((inhibit-redisplay t)) ;; not sure if this is doing anything but FWIW
-      (rigpa-buffer-return-to-original)
-      (evil-switch-to-windows-last-buffer))))
+  (let ((exit-buffer (current-buffer))
+        (original-buffer (rigpa-buffer-original-buffer)))
+    (unless (eq exit-buffer original-buffer)
+      ;; rotate the ring back so the original buffer is at head, and
+      ;; then surface the exit buffer so it's proximate to the original
+      (dynaring-rotate-until (buffer-ring-ring-ring (buffer-ring-current-ring))
+                             #'dynaring-rotate-right
+                             (lambda (buf)
+                               (eq original-buffer buf)))
+      (buffer-ring-surface-buffer exit-buffer))))
 
 (defun rigpa-buffer--active-buffers ()
   "Get active buffers."
-  (if (eq rigpa--complex rigpa-meta-tower-complex)
-      (seq-filter (lambda (buf)
-                    (s-starts-with-p rigpa-buffer-prefix (buffer-name buf)))
-                  (buffer-list))
-    (seq-filter (lambda (buf)
-                  ;; names of "invisible" buffers start with a space
-                  ;; https://www.emacswiki.org/emacs/InvisibleBuffers
-                  (not (s-starts-with-p " " (buffer-name buf))))
-                (buffer-list))))
+  (seq-reverse ; for consistency with next-buffer / prev-buffer directions
+   (if (eq rigpa--complex rigpa-meta-tower-complex)
+       (seq-filter (lambda (buf)
+                     (s-starts-with-p rigpa-buffer-prefix (buffer-name buf)))
+                   (buffer-list))
+     (seq-filter (lambda (buf)
+                   ;; names of "invisible" buffers start with a space
+                   ;; https://www.emacswiki.org/emacs/InvisibleBuffers
+                   (and (not (s-starts-with-p " " (buffer-name buf)))
+                        (not (member (buffer-name buf) rigpa-buffer-ignore-buffers))))
+                 (buffer-list)))))
 
 (defun rigpa-buffer-create-ring ()
   "Create the buffer ring upon entry into buffer mode."
   (interactive)
   ;; delete buffer ring and rebuild from scratch each time, for now,
   ;; instead of maintaining a persistent buffer ring via hooks
-  (message "CREATING RING...")
   (let* ((ring-name (if (eq rigpa--complex rigpa-meta-tower-complex)
                         "2"
                       "0")) ; TODO: derive from coordinates later
          (buffer-ring-name (concat rigpa-buffer-ring-name-prefix
                                    "-"
-                                   ring-name)))
-    (buffer-ring-torus-delete-ring buffer-ring-name)
-    (dolist (buf (rigpa-buffer--active-buffers))
-      (buffer-ring-add buffer-ring-name buf))
-    ;; surface the current buffer for ab initio
-    ;; synchronization. It might make sense for buffer-ring
-    ;; to provide an interface `buffer-ring-create-with-buffers`
-    ;; that handles this, since it's a "chariot" necessity
-    ;; and not a factor while adding single buffers
-    (buffer-ring-surface-buffer (current-buffer))
-    (buffer-ring-torus-switch-to-ring buffer-ring-name)
-    (message "buffer ring size is %s" (buffer-ring-size))))
+                                   ring-name))
+         (ring-buffer-hash (make-hash-table :test #'equal)))
+    ;; add any buffers in the current active list of buffers
+    ;; to the buffer ring that aren't already there (e.g. buffers
+    ;; created since the last entry into buffer mode). If this is
+    ;; the first entry into buffer mode, create the buffer ring
+    ;; from scratch with all of the currently active buffers
+    (let ((active-buffers (rigpa-buffer--active-buffers))
+          (ring-buffers (dynaring-values
+                         (buffer-ring-ring-ring
+                          (buffer-ring-torus-get-ring buffer-ring-name)))))
+      (dolist (buf ring-buffers)
+        (puthash (buffer-name buf) t ring-buffer-hash))
+      (let ((fresh-buffers
+             (seq-filter (lambda (buf)
+                           (not (gethash (buffer-name buf)
+                                         ring-buffer-hash)))
+                         active-buffers)))
+        ;; we could just add all the buffers to the ring naively,
+        ;; and that would be fine since buffer-ring takes no action
+        ;; if the buffer happens to already be a member. But we don't
+        ;; do that since each time this happens a message is echoed
+        ;; to indicate that to the user, and the cost of I/O over
+        ;; possibly hundreds of buffer additions could add a perceptible
+        ;; lag in buffer mode entry. So we efficiently compute the
+        ;; difference and just add those buffers
+        (dolist (buf fresh-buffers)
+          (buffer-ring-add buffer-ring-name buf))
+        (buffer-ring-torus-switch-to-ring buffer-ring-name)
+        (message "buffer ring size is %s" (buffer-ring-size))))))
 
 (defun rigpa-buffer--setup-buffer-marks-table ()
   "Initialize the buffer marks hashtable and add an entry for the
@@ -219,21 +254,31 @@ current ('original') buffer."
   (rigpa-buffer-return-to-original)
   (ivy-switch-buffer))
 
+(defun rigpa-buffer-alternate ()
+  "Switch to most recent buffer."
+  (interactive)
+  (let* ((ring (buffer-ring-ring-ring (buffer-ring-current-ring)))
+         (other-buffer (dynaring-segment-value
+                        (dynaring-segment-next (dynaring-head ring)))))
+    ;; we can't simply rotate because we want to reinsert (i.e. "break insert")
+    ;; it so that recency ordering reflects correctly
+    (buffer-ring-switch-to-buffer other-buffer)))
+
 (defhydra hydra-buffer (:columns 3
                         :body-pre (progn (rigpa-buffer--setup-buffer-marks-table)
                                          (chimera-hydra-signal-entry chimera-buffer-mode)
                                          (rigpa-buffer-create-ring)) ; maybe put in ad-hoc entry
-                        :post (progn (rigpa-buffer-flash-to-original)
+                        :post (progn (rigpa-buffer-link-to-original)
                                      (chimera-hydra-portend-exit chimera-buffer-mode t))
                         :after-exit (chimera-hydra-signal-exit chimera-buffer-mode
                                                                #'chimera-handle-hydra-exit))
   "Buffer mode"
-  ("s-b" evil-switch-to-windows-last-buffer "switch to last" :exit t)
-  ("b" evil-switch-to-windows-last-buffer "switch to last" :exit t)
-  ("h" buffer-ring-prev-buffer "previous")
+  ("s-b" rigpa-buffer-alternate "switch to last" :exit t)
+  ("b" rigpa-buffer-alternate "switch to last" :exit t)
+  ("h" buffer-ring-next-buffer "previous")
   ("j" ignore nil)
   ("k" ignore nil)
-  ("l" buffer-ring-next-buffer "next")
+  ("l" buffer-ring-prev-buffer "next")
   ("y" rigpa-buffer-yank "yank")
   ("p" rigpa-buffer-paste "paste")
   ("n" (lambda ()

--- a/rigpa-buffer-mode.el
+++ b/rigpa-buffer-mode.el
@@ -156,6 +156,8 @@ happen quickly enough not to be noticeable."
                     (s-starts-with-p rigpa-buffer-prefix (buffer-name buf)))
                   (buffer-list))
     (seq-filter (lambda (buf)
+                  ;; names of "invisible" buffers start with a space
+                  ;; https://www.emacswiki.org/emacs/InvisibleBuffers
                   (not (s-starts-with-p " " (buffer-name buf))))
                 (buffer-list))))
 
@@ -173,7 +175,15 @@ happen quickly enough not to be noticeable."
                                    ring-name)))
     (buffer-ring-torus-delete-ring buffer-ring-name)
     (dolist (buf (rigpa-buffer--active-buffers))
-      (buffer-ring-add buffer-ring-name buf))))
+      (buffer-ring-add buffer-ring-name buf))
+    ;; surface the current buffer for ab initio
+    ;; synchronization. It might make sense for buffer-ring
+    ;; to provide an interface `buffer-ring-create-with-buffers`
+    ;; that handles this, since it's a "chariot" necessity
+    ;; and not a factor while adding single buffers
+    (buffer-ring-surface-buffer (current-buffer))
+    (buffer-ring-torus-switch-to-ring buffer-ring-name)
+    (message "buffer ring size is %s" (buffer-ring-size))))
 
 (defun rigpa-buffer--setup-buffer-marks-table ()
   "Initialize the buffer marks hashtable and add an entry for the

--- a/rigpa-custom.el
+++ b/rigpa-custom.el
@@ -1,0 +1,34 @@
+;;; rigpa-custom.el --- Self-reflective editing modes -*- lexical-binding: t -*-
+
+;; URL: https://github.com/countvajhula/rigpa
+
+;; This program is "part of the world," in the sense described at
+;; http://drym.org.  From your perspective, this is no different than
+;; MIT or BSD or other such "liberal" licenses that you may be
+;; familiar with, that is to say, you are free to do whatever you like
+;; with this program.  It is much more than BSD or MIT, however, in
+;; that it isn't a license at all but an idea about the world and how
+;; economic systems could be set up so that everyone wins.  Learn more
+;; at drym.org.
+;;
+;; This work transcends traditional legal and economic systems, but
+;; for the purposes of any such systems within which you may need to
+;; operate:
+;;
+;; This is free and unencumbered software released into the public domain.
+;; The authors relinquish any copyright claims on this work.
+;;
+
+;;; Commentary:
+;;
+;; User customizations
+;;
+
+;;; Code:
+
+(defgroup rigpa nil
+  "A metacircular UI framework."
+  :group 'Emacs)
+
+(provide 'rigpa-custom)
+;;; rigpa-custom.el ends here

--- a/rigpa-meta.el
+++ b/rigpa-meta.el
@@ -48,8 +48,7 @@ to terminate the reference chain."
   ;;(setq cursor-type nil))
   (internal-show-cursor nil nil)
   (when display-line-numbers-mode
-    (display-line-numbers-mode -1))
-  (hl-line-mode))
+    (display-line-numbers-mode -1)))
 
 (defun rigpa--set-ui-for-meta-modes ()
   "Set (for now, global) UI parameters for meta modes."

--- a/rigpa-mode-mode.el
+++ b/rigpa-mode-mode.el
@@ -391,7 +391,8 @@ current editing tower."
                        rigpa--current-tower-index)))
     (switch-to-buffer             ; TODO: base this on "state" instead
      (rigpa--buffer-name
-      (rigpa--tower tower-index)))))
+      (rigpa--tower tower-index)))
+    (rigpa--enter-appropriate-mode)))
 
 (defun rigpa-exit-mode-mode ()
   "Exit mode mode."

--- a/rigpa-tower-mode.el
+++ b/rigpa-tower-mode.el
@@ -144,7 +144,6 @@
       (setq rigpa--ground-buffer ground)
       (rigpa--set-meta-buffer-appearance)
       (insert (rigpa-serialize-tower tower))
-      (rigpa--enter-appropriate-mode)
       ;; store the tower index in the buffer so it can be read
       ;; in the tower buffer navigation side effect
       (setq-local rigpa--tower-index tower-index))
@@ -226,8 +225,10 @@ initial editing tower."
   (let ((tower-index (with-current-buffer (rigpa--get-ground-buffer)
                        rigpa--current-tower-index)))
     (switch-to-buffer
-     (rigpa--buffer-name
-      (rigpa--tower tower-index)))))
+     (let ((name (rigpa--buffer-name
+                  (rigpa--tower tower-index))))
+       name))
+    (rigpa--enter-appropriate-mode)))
 
 (defun rigpa-exit-tower-mode ()
   "Exit tower mode."

--- a/rigpa-tower-mode.el
+++ b/rigpa-tower-mode.el
@@ -237,14 +237,14 @@ monadic verb in the 'switch buffer' navigation."
 (defun rigpa--add-meta-tower-side-effects ()
   "Add side effects for primitive mode operations while in meta mode."
   ;; this should lookup the appropriate side-effect based on the coordinates
-  (advice-add #'previous-buffer :around #'rigpa--previous-tower-wrapper)
-  (advice-add #'next-buffer :around #'rigpa--next-tower-wrapper))
+  (advice-add #'buffer-ring-prev-buffer :around #'rigpa--previous-tower-wrapper)
+  (advice-add #'buffer-ring-next-buffer :around #'rigpa--next-tower-wrapper))
 
 ;; ensure the meta and meta-tower's are straight
 (defun rigpa--remove-meta-tower-side-effects ()
   "Remove side effects for primitive mode operations that were added for meta modes."
-  (advice-remove #'previous-buffer #'rigpa--previous-tower-wrapper)
-  (advice-remove #'next-buffer #'rigpa--next-tower-wrapper))
+  (advice-remove #'buffer-ring-prev-buffer #'rigpa--previous-tower-wrapper)
+  (advice-remove #'buffer-ring-next-buffer #'rigpa--next-tower-wrapper))
 
 (defun rigpa-enter-tower-mode ()
   "Enter a buffer containing a textual representation of the

--- a/rigpa-tower-mode.el
+++ b/rigpa-tower-mode.el
@@ -225,9 +225,8 @@ initial editing tower."
   (let ((tower-index (with-current-buffer (rigpa--get-ground-buffer)
                        rigpa--current-tower-index)))
     (switch-to-buffer
-     (let ((name (rigpa--buffer-name
-                  (rigpa--tower tower-index))))
-       name))
+     (rigpa--buffer-name
+      (rigpa--tower tower-index)))
     (rigpa--enter-appropriate-mode)))
 
 (defun rigpa-exit-tower-mode ()

--- a/rigpa-tower-mode.el
+++ b/rigpa-tower-mode.el
@@ -94,19 +94,6 @@
     ;; the name of the tower
     (narrow-to-region start end)))
 
-(defun rigpa--switch-to-tower (tower-id)
-  "View the tower indicated, reflecting the state of the ground buffer."
-  ;; "view" tower
-  ;; this should be replaced with meta buffer mode and any applicable side-effects
-  (interactive)
-  (let ((tower (rigpa--tower tower-id)))
-    (switch-to-buffer (rigpa--buffer-name tower))
-    (rigpa--tower-view-narrow tower)
-    (rigpa--tower-view-reflect-ground tower)
-    (with-current-buffer (rigpa--get-ground-buffer)
-      ;; ad hoc modeling of buffer mode side effect here
-      (setq rigpa--current-tower-index tower-id))))
-
 (defun rigpa-serialize-tower (tower)
   "A string representation of a tower."
   (let ((tower-height (rigpa-ensemble-size tower))
@@ -142,38 +129,25 @@
       (rigpa--tower-view-narrow tower)
       tower)))
 
-(defun rigpa-render-tower-for-mode-mode (tower &optional major-mode)
+(defun rigpa-render-tower (tower tower-index ground &optional major-mode)
   "Render a text representation of an editing tower in a buffer."
   (interactive)
-  (let* ((ground (current-buffer))
-         (major-mode (or major-mode #'rigpa-meta-mode))
+  (let* ((major-mode (or major-mode #'rigpa-meta-mode))
          (buffer (rigpa-buffer-create (rigpa--buffer-name tower)
                                       major-mode)))
     (with-current-buffer buffer
-      ;; ground buffer is inherited from the original
+      ;; in tower mode, ground buffer is inherited from the original
       ;; to define the chain of reference
-      (setq rigpa--ground-buffer
-            ground)
+      ;; in mode mode, the ground isn't inherited from the
+      ;; current buffer; instead, the current buffer itself becomes
+      ;; the new ground
+      (setq rigpa--ground-buffer ground)
       (rigpa--set-meta-buffer-appearance)
       (insert (rigpa-serialize-tower tower))
-      (rigpa--enter-appropriate-mode))
-    buffer))
-
-(defun rigpa-render-tower (tower &optional major-mode)
-  "Render a text representation of an editing tower in a buffer."
-  (interactive)
-  (let* ((inherited-ground-buffer (rigpa--get-ground-buffer))
-         (major-mode (or major-mode #'rigpa-meta-mode))
-         (buffer (rigpa-buffer-create (rigpa--buffer-name tower)
-                                      major-mode)))
-    (with-current-buffer buffer
-      ;; ground buffer is inherited from the original
-      ;; to define the chain of reference
-      (setq rigpa--ground-buffer
-            inherited-ground-buffer)
-      (rigpa--set-meta-buffer-appearance)
-      (insert (rigpa-serialize-tower tower))
-      (rigpa--enter-appropriate-mode))
+      (rigpa--enter-appropriate-mode)
+      ;; store the tower index in the buffer so it can be read
+      ;; in the tower buffer navigation side effect
+      (setq-local rigpa--tower-index tower-index))
     buffer))
 
 (defun rigpa-flashback-to-last-tower ()
@@ -198,63 +172,47 @@ monadic verb in the 'switch buffer' navigation."
     ;; enter the appropriate level in the new tower
     (rigpa--enter-appropriate-mode)))
 
-(defun rigpa-previous-tower ()
-  "Previous tower"
-  (interactive)
+(defun rigpa--view-tower-wrapper (orig-fn &rest args)
+  "Focus and contextualize the view of the tower, and update the tower
+index in the ground buffer to reflect the selected one."
+  (let ((result (apply orig-fn args)))
+    (let* ((tower-id rigpa--tower-index) ; read from the buffer-local variable
+           (tower (with-current-buffer (rigpa--get-ground-buffer)
+                    (rigpa--tower tower-id))))
+      (rigpa--view-tower tower)
+      (rigpa--update-ground-tower-index tower-id))
+    result))
+
+(defun rigpa--view-tower (tower)
+  "Focus and contextualize the view of the tower."
+  (rigpa--tower-view-narrow tower)
+  (rigpa--tower-view-reflect-ground tower))
+
+(defun rigpa--update-ground-tower-index (tower-id)
+  "Update ground tower index to TOWER-ID."
   (with-current-buffer (rigpa--get-ground-buffer)
-    (let ((tower-id (mod (1- rigpa--current-tower-index)
-                         (rigpa-ensemble-size rigpa--complex))))
-     (rigpa--switch-to-tower tower-id))))
-
-(defun rigpa-next-tower ()
-  "Next tower"
-  (interactive)
-  (with-current-buffer (rigpa--get-ground-buffer)
-    (let ((tower-id (mod (1+ rigpa--current-tower-index)
-                         (rigpa-ensemble-size rigpa--complex))))
-     (rigpa--switch-to-tower tower-id))))
-
-;; probably what we want is:
-;; 1. set up a "primary" buffer ring for all buffers at init time
-;;    and ensure all open buffers in buffer-list are part of it
-;; 2. use buffer-ring-next/previous in buffer mode
-;; 3. for tower mode,
-;;    (1) switch to a new "tower" ring, and
-;;    (2) add a side effect to buffer-ring-next/previous
-;;        to modify the tower index in the ground buffer
-;; Later, worry about moving all of these to "coordinates"
-;; and also about improving the buffer ring interface with
-;; explicit constructors and so on, and performance with
-;; hashes instead of simple conses if it becomes a problem
-(defun rigpa--previous-tower-wrapper (orig-fn &rest args)
-  "Thin wrapper to disregard actual buffer change functions (temporary hack)."
-  (rigpa-previous-tower))
-
-(defun rigpa--next-tower-wrapper (orig-fn &rest args)
-  "Thin wrapper to disregard actual buffer change functions (temporary hack)."
-  (rigpa-next-tower))
+    (setq rigpa--current-tower-index tower-id)))
 
 (defun rigpa--add-meta-tower-side-effects ()
   "Add side effects for primitive mode operations while in meta mode."
   ;; this should lookup the appropriate side-effect based on the coordinates
-  (advice-add #'buffer-ring-prev-buffer :around #'rigpa--previous-tower-wrapper)
-  (advice-add #'buffer-ring-next-buffer :around #'rigpa--next-tower-wrapper))
+  (advice-add #'switch-to-buffer :around #'rigpa--view-tower-wrapper))
 
 ;; ensure the meta and meta-tower's are straight
 (defun rigpa--remove-meta-tower-side-effects ()
   "Remove side effects for primitive mode operations that were added for meta modes."
-  (advice-remove #'buffer-ring-prev-buffer #'rigpa--previous-tower-wrapper)
-  (advice-remove #'buffer-ring-next-buffer #'rigpa--next-tower-wrapper))
+  (advice-remove #'switch-to-buffer #'rigpa--view-tower-wrapper))
 
 (defun rigpa-enter-tower-mode ()
   "Enter a buffer containing a textual representation of the
 initial editing tower."
   (interactive)
-  (with-current-buffer (rigpa--get-ground-buffer)
-    (dolist (tower (editing-ensemble-members rigpa--complex))
-      (rigpa-render-tower tower #'rigpa-meta-tower-mode)))
-  ;; TODO: is it necessary to reference ground buffer here?
-  ;;
+  (let* ((ground (rigpa--get-ground-buffer))
+         (towers (with-current-buffer ground
+                   (editing-ensemble-members rigpa--complex))))
+    (dotimes (i (length towers))
+      (let ((tower (nth i towers)))
+        (rigpa-render-tower tower i ground #'rigpa-meta-tower-mode))))
   ;; Store "previous" previous tower to support flashback
   ;; feature seamlessly. This is to get around hydra executing
   ;; functions after exiting rather than before, which loses
@@ -263,10 +221,13 @@ initial editing tower."
   ;; Improve this eventually.
   (setq rigpa--flashback-tower-index rigpa--tower-index-on-entry)
   (setq rigpa--tower-index-on-entry rigpa--current-tower-index)
-  (with-current-buffer (rigpa--get-ground-buffer)
-    (rigpa--switch-to-tower rigpa--current-tower-index))
   (rigpa--add-meta-tower-side-effects)
-  (rigpa--set-ui-for-meta-modes))
+  (rigpa--set-ui-for-meta-modes)
+  (let ((tower-index (with-current-buffer (rigpa--get-ground-buffer)
+                       rigpa--current-tower-index)))
+    (switch-to-buffer
+     (rigpa--buffer-name
+      (rigpa--tower tower-index)))))
 
 (defun rigpa-exit-tower-mode ()
   "Exit tower mode."
@@ -279,40 +240,6 @@ initial editing tower."
     (kill-matching-buffers (concat "^" rigpa-buffer-prefix) nil t)
     (switch-to-buffer ref-buf)))
 
-(defhydra hydra-tower (:idle 1.0
-                       :columns 4
-                       :body-pre (rigpa-enter-tower-mode)
-                       :post (rigpa-exit-tower-mode))
-  "Tower mode"
-  ;; Need a textual representation of the mode tower for these to operate on
-  ("h" rigpa-previous-tower "previous tower")
-  ("j" rigpa-select-next-level "lower level")
-  ("k" rigpa-select-previous-level "higher level")
-  ("l" rigpa-next-tower "next tower")
-  ;; ("H" rigpa-highest-level "first level (recency)")
-  ;; ("J" rigpa-lowest-level "lowest level")
-  ;; ("K" rigpa-highest-level "highest level")
-  ;; ("L" rigpa-lowest-level "last level (recency)")
-  ;; different towers for different "major modes"
-  ;; ("s-o" rigpa-mode-mru "Jump to most recent (like Alt-Tab)" :exit t)
-  ;; ("o" rigpa-mode-mru :exit t)
-  ;; with delete / change etc. we could construct towers and then select towers
-  ;; there could be a maximal tower containing all the levels
-  ;; ("/" rigpa-search "search")
-  ;; move to change ordering of levels, an alternative to recency
-  ;;
-  ;; ffap other window -- open file with this other mode/tower: a formal "major mode"
-  ;; the mode mode, tower mode, and so on recursively makes more sense
-  ;; if we assume that keyboard shortcuts are scarce. this gives us ways to use
-  ;; a small number of keys in any arbitrary configuration
-  ("s-m" rigpa-flashback-to-last-tower "flashback" :exit t)  ; canonical action
-  ("<return>" rigpa-enter-selected-level "enter selected level" :exit t)
-  ("s-<return>" rigpa-enter-selected-level "enter selected level" :exit t)
-  ("i" nil "exit" :exit t)
-  ("<escape>" nil "exit" :exit t))
-
-  ;("s-<return>" rigpa-enter-lower-level "enter lower level" :exit t)
-  ;("s-<escape>" rigpa-enter-higher-level "escape to higher level" :exit t))
 
 (provide 'rigpa-tower-mode)
 ;;; rigpa-tower-mode.el ends here

--- a/rigpa.el
+++ b/rigpa.el
@@ -3,7 +3,7 @@
 ;; Author: Siddhartha Kasivajhula <sid@countvajhula.com>
 ;; URL: https://github.com/countvajhula/rigpa
 ;; Version: 0.1
-;; Package-Requires: ((emacs "26.1") (evil "1.2.14") (hydra "0.15.0") (symex "0.8.1") (dynaring "0.2.0") (buffer-ring "0.2") (ivy "0.13.0") (centaur-tabs "3.1") (beacon "1.3.4") (dictionary "1.11") (ace-window "0.9.0") (git-timemachine "4.11") (parsec "0.1.3") (ht "2.0") (s "1.12.0") (dash "2.18.0"))
+;; Package-Requires: ((emacs "26.1") (evil "1.2.14") (hydra "0.15.0") (symex "0.8.1") (dynaring "0.3") (buffer-ring "0.3") (ivy "0.13.0") (centaur-tabs "3.1") (beacon "1.3.4") (dictionary "1.11") (ace-window "0.9.0") (git-timemachine "4.11") (parsec "0.1.3") (ht "2.0") (s "1.12.0") (dash "2.18.0"))
 ;; Keywords: emulations, frames, convenience
 
 ;; This program is "part of the world," in the sense described at

--- a/rigpa.el
+++ b/rigpa.el
@@ -46,6 +46,7 @@
 (require 'hydra)
 (require 'chimera)
 (require 'ht)
+(require 'rigpa-custom)
 (require 'rigpa-char-mode)
 (require 'rigpa-word-mode)
 (require 'rigpa-line-mode)

--- a/rigpa.el
+++ b/rigpa.el
@@ -3,7 +3,7 @@
 ;; Author: Siddhartha Kasivajhula <sid@countvajhula.com>
 ;; URL: https://github.com/countvajhula/rigpa
 ;; Version: 0.1
-;; Package-Requires: ((emacs "26.1") (evil "1.2.14") (hydra "0.15.0") (symex "0.8.1") (ivy "0.13.0") (centaur-tabs "3.1") (beacon "1.3.4") (dictionary "1.11") (ace-window "0.9.0") (git-timemachine "4.11") (parsec "0.1.3") (ht "2.0") (dash "2.18.0"))
+;; Package-Requires: ((emacs "26.1") (evil "1.2.14") (hydra "0.15.0") (symex "0.8.1") (ivy "0.13.0") (centaur-tabs "3.1") (beacon "1.3.4") (dictionary "1.11") (ace-window "0.9.0") (git-timemachine "4.11") (parsec "0.1.3") (ht "2.0") (s "1.12.0") (dash "2.18.0"))
 ;; Keywords: emulations, frames, convenience
 
 ;; This program is "part of the world," in the sense described at

--- a/rigpa.el
+++ b/rigpa.el
@@ -3,7 +3,7 @@
 ;; Author: Siddhartha Kasivajhula <sid@countvajhula.com>
 ;; URL: https://github.com/countvajhula/rigpa
 ;; Version: 0.1
-;; Package-Requires: ((emacs "26.1") (evil "1.2.14") (hydra "0.15.0") (symex "0.8.1") (ivy "0.13.0") (centaur-tabs "3.1") (beacon "1.3.4") (dictionary "1.11") (ace-window "0.9.0") (git-timemachine "4.11") (parsec "0.1.3") (ht "2.0") (s "1.12.0") (dash "2.18.0"))
+;; Package-Requires: ((emacs "26.1") (evil "1.2.14") (hydra "0.15.0") (symex "0.8.1") (dynaring "0.2.0") (buffer-ring "0.2") (ivy "0.13.0") (centaur-tabs "3.1") (beacon "1.3.4") (dictionary "1.11") (ace-window "0.9.0") (git-timemachine "4.11") (parsec "0.1.3") (ht "2.0") (s "1.12.0") (dash "2.18.0"))
 ;; Keywords: emulations, frames, convenience
 
 ;; This program is "part of the world," in the sense described at


### PR DESCRIPTION
**Summary**: Use a buffer ring structure to power "buffer mode," and leverage the same structure in tower mode via meta mode side effects.

**More detail**:

A core idea in rigpa is that "ground level" modes should be usable in "meta level" representations without any essential changes, with their meaning only modulated via side effects on their existing behavior.

At the moment, rigpa's buffer mode uses built-in Emacs buffer navigations. As Emacs has no idea about rigpa's "meta" modes, towers depicted in buffers in a meta mode are treated as buffers like any other by emacs's buffer navigation. Using built-in buffer navigations naively would cause non-tower buffers to be visited while we are in tower mode. In order to achieve the desired behavior, at the moment, the ground level behavior is simply overridden with the meta level behavior rather than layered on as a side effect. We'd instead like to have some way to define the "space" that buffer mode is to navigate, so that it works the same way at any level once the space is appropriately bounded.

This PR modifies buffer mode to use the buffer-ring package instead of Emacs's built-in navigations directly. A buffer ring data structure is used to hold the buffers, and the buffer navigation commands are now ring traversal commands instead. This allows us to change the behavior of buffer mode in a meta level by simply changing the ring that it is operating on. In addition, by defining our own primitive buffer representation as we are doing here, we derive a lot more flexibility for tailoring the behavior, for instance, in terms of recency or any other criteria.

Merging this is blocked, pending https://github.com/melpa/melpa/pull/7469 and https://github.com/melpa/melpa/pull/7470 .
