### PR TITLE
Resolves #8 Set face font to 'unspecified when 'default face is 'unspecified

### DIFF
--- a/rigpa.el
+++ b/rigpa.el
@@ -71,7 +71,10 @@
                       "Consolas")
                      ((find-font (font-spec :name "Courier New"))
                       "Courier New")
-                     (t (font-get (face-attribute 'default :font) :name))))
+                     (t (let ((font (face-attribute 'default :font)))
+                          (if (eq font 'unspecified)
+                              'unspecified
+                            (font-get font :name))))))
 
 (set-face-foreground 'rigpa-face "tomato")
 


### PR DESCRIPTION
#When running emacs with the -nw flag, `(face-attribute 'default :font)` evaluates to `'undefined`, which was causing an error when passed to `#'font-get`. Ultimate this prevented the file from being loaded when running emacs in a terminal.

This change fixes that problem by ensuring that `(font-get font :name)` is only called when `font` is not `'undefined`.

I also submitted an issue for this: #8 