### PR TITLE
Remove dependency on counsel

### DIFF
--- a/rigpa-application-mode.el
+++ b/rigpa-application-mode.el
@@ -31,7 +31,6 @@
 (require 'chimera-hydra)
 (require 'centaur-tabs)
 (require 'beacon)
-(require 'counsel)
 
 (defvar rigpa-application--original-transparency 100)
 
@@ -127,6 +126,14 @@
   ("q" rigpa-application-return-to-original-transparency  "return to original transparency" :exit t)
   ("<escape>" ignore "quit" :exit t))
 
+(fset (intern "rigpa-application-load-theme")
+      (symbol-function
+       (cond ((require 'counsel nil t)
+              'counsel-load-theme)
+             ((require 'consult nil t)
+              'consult-theme)
+             (t 'load-theme))))
+
 (defhydra hydra-application (:columns 2
                              :exit t
                              :body-pre (chimera-hydra-signal-entry chimera-application-mode)
@@ -141,7 +148,7 @@
   ("B" beacon-mode "toggle beacon")
   ("s" scroll-bar-mode "toggle scroll bar")
   ("l" hl-line-mode "toggle highlight line")
-  ("c" counsel-load-theme "change color scheme")
+  ("c" rigpa-application-load-theme "change color scheme")
   ("f" set-frame-font "change font")
   ("H-m" rigpa-toggle-menu "show/hide this menu" :exit nil)
   ("<return>" rigpa-enter-lower-level "enter lower level")


### PR DESCRIPTION
### Summary of Changes

rigpa-application-mode depends on counsel.el only for its single
invocation of `counsel-load-theme` in the rigpa-application hydra. This
change removes that dependency by conditionally selecting an appropriate
function to insert into the hydra. It for the first available function
in the following order:

1. counsel-load-theme
2. consult-theme
3. load-theme

### Public Domain Dedication

- [X] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
