### PR TITLE
Introduce mode rings

### DIFF
--- a/rigpa-mode-mode.el
+++ b/rigpa-mode-mode.el
@@ -308,11 +308,11 @@ is precisely the thing to be done."
           (recall rigpa-recall))
       ;; only set recall here if it is currently in the tower AND
       ;; going to a state outside the tower
-      (when (and (rigpa-ensemble-member-position-by-name (rigpa--local-tower)
-                                                         mode-name)
-                 (not (rigpa-ensemble-member-position-by-name
-                       (rigpa--local-tower)
-                       (symbol-name evil-next-state))))
+      (when (and (rigpa--member-of-ensemble-p (rigpa--local-tower)
+                                              mode-name)
+                 (not
+                  (rigpa--member-of-ensemble-p (rigpa--local-tower)
+                                               (symbol-name evil-next-state))))
         (rigpa-set-mode-recall mode-name)))))
 
 (defun rigpa-set-mode-recall (mode-name)

--- a/rigpa-mode-mode.el
+++ b/rigpa-mode-mode.el
@@ -107,8 +107,8 @@ MODE."
 
 (defun rigpa--native-p (mode)
   "Is MODE native to the local editing ensemble (e.g. tower)?"
-  (rigpa--member-of-ensemble-p mode
-                               (rigpa--local-tower)))
+  (rigpa--member-of-ensemble-p (rigpa--local-tower)
+                               mode))
 
 (defun rigpa-enter-mode (mode-name)
   "Enter mode MODE-NAME.

--- a/rigpa-mode-mode.el
+++ b/rigpa-mode-mode.el
@@ -107,8 +107,17 @@ MODE."
 
 (defun rigpa--native-p (mode)
   "Is MODE native to the local editing ensemble (e.g. tower)?"
-  (rigpa--member-of-ensemble-p (rigpa--local-tower)
-                               mode))
+  (or (rigpa--member-of-ensemble-p (rigpa--local-tower)
+                                   ;; TODO: can make this dynaringp dynaring-value, etc.
+                                   ;; but that doesn't quite work since the ensemble-position-by-name
+                                   ;; derives the list to check for membership from the head value of the ring
+                                   (rigpa-editing-entity-name mode))
+      ;; a hack just to check if it works.
+      ;; there's a ghost third element in the ring, it seems (but not actually since its size is 2)
+      ;; when hitting Esc to rotate (verify what Esc is bound to)
+      (and (equal "lisp" (rigpa-editing-entity-name (rigpa--local-tower)))
+           (member (rigpa-editing-entity-name mode)
+                   (list "symex" "normal")))))
 
 (defun rigpa-enter-mode (mode-name)
   "Enter mode MODE-NAME.

--- a/rigpa-mode-mode.el
+++ b/rigpa-mode-mode.el
@@ -132,6 +132,10 @@ upon exit, we are implicitly returned to a native mode."
                             0)))
     (let ((mode-name (rigpa-editing-entity-name
                       (rigpa-ensemble-member-at-position tower level-number))))
+      ;; so, we're expecting the tower to be a list containing
+      ;; _modes_. Instead, we want to change it to contain
+      ;; _mode rings_. Let's first convert it into a mode ring
+      ;; containing a single element.
       (rigpa-enter-mode mode-name)
       (setq rigpa--current-level level-number))))
 

--- a/rigpa-mode-mode.el
+++ b/rigpa-mode-mode.el
@@ -32,6 +32,7 @@
 (require 'rigpa-text-parsers)
 (require 'rigpa-meta)
 (require 'rigpa-evil-support)
+(require 'dynaring)
 
 (evil-define-state mode
   "Mode state."
@@ -123,15 +124,44 @@ upon exit, we are implicitly returned to a native mode."
         (chimera-switch-mode to-mode)
       (chimera--enter-mode to-mode))))
 
+(defun rigpa--rotate-mode-ring (direction)
+  "Rotate the current mode ring in DIRECTION."
+  (interactive)
+  (let* ((tower (rigpa--local-tower))
+         (tower-height (rigpa-ensemble-size tower))
+         (level-number (max (min rigpa--current-level
+                                 (1- tower-height))
+                            0))
+         (ring (rigpa-ensemble-member-at-position tower
+                                                  level-number)))
+    (funcall direction ring)
+    (rigpa-enter-mode
+     (rigpa-editing-entity-name
+      (dynaring-value ring)))))
+
+(defun rigpa-rotate-mode-ring-left ()
+  "Rotate the current mode ring to the left."
+  (interactive)
+  (rigpa--rotate-mode-ring #'dynaring-rotate-left))
+
+(defun rigpa-rotate-mode-ring-right ()
+  "Rotate the current mode ring to the right."
+  (interactive)
+  (rigpa--rotate-mode-ring #'dynaring-rotate-right))
+
 (defun rigpa--enter-level (level-number)
   "Enter level LEVEL-NUMBER"
   (let* ((tower (rigpa--local-tower))
          (tower-height (rigpa-ensemble-size tower))
          (level-number (max (min level-number
                                  (1- tower-height))
-                            0)))
-    (let ((mode-name (rigpa-editing-entity-name
-                      (rigpa-ensemble-member-at-position tower level-number))))
+                            0))
+         (level (rigpa-ensemble-member-at-position tower
+                                                   level-number))
+         (mode (if (dynaringp level)
+                   (dynaring-value level)
+                 level)))
+    (let ((mode-name (rigpa-editing-entity-name mode)))
       ;; so, we're expecting the tower to be a list containing
       ;; _modes_. Instead, we want to change it to contain
       ;; _mode rings_. Let's first convert it into a mode ring
@@ -291,7 +321,7 @@ is precisely the thing to be done."
 
 (defun rigpa-serialize-mode (mode tower level-number)
   "A string representation of a mode."
-  (let ((name (rigpa-editing-entity-name mode)))
+  (let ((name (rigpa-editing-entity-name (if (dynaringp mode) (dynaring-value mode) mode))))
     (concat "|―――"
             (number-to-string level-number)
             "―――|"

--- a/rigpa-mode-mode.el
+++ b/rigpa-mode-mode.el
@@ -143,10 +143,11 @@ upon exit, we are implicitly returned to a native mode."
                             0))
          (ring (rigpa-ensemble-member-at-position tower
                                                   level-number)))
-    (funcall direction ring)
-    (rigpa-enter-mode
-     (rigpa-editing-entity-name
-      (dynaring-value ring)))))
+    (when (dynaringp ring)
+      (funcall direction ring)
+      (rigpa-enter-mode
+       (rigpa-editing-entity-name
+        (dynaring-value ring))))))
 
 (defun rigpa-rotate-mode-ring-left ()
   "Rotate the current mode ring to the left."

--- a/rigpa-mode-mode.el
+++ b/rigpa-mode-mode.el
@@ -158,6 +158,15 @@ upon exit, we are implicitly returned to a native mode."
   (interactive)
   (rigpa--rotate-mode-ring #'dynaring-rotate-right))
 
+(defun rigpa-escape-or-rotate ()
+  "Escape to a higher level or rotate mode ring.
+
+Tries these actions in that order."
+  (if (< rigpa--current-level
+         (1- (rigpa-ensemble-size (rigpa--local-tower))))
+      (rigpa--enter-level (1+ rigpa--current-level))
+    (rigpa-rotate-mode-ring-left)))
+
 (defun rigpa--enter-level (level-number)
   "Enter level LEVEL-NUMBER"
   (let* ((tower (rigpa--local-tower))

--- a/rigpa-mode-mode.el
+++ b/rigpa-mode-mode.el
@@ -195,7 +195,7 @@ Tries these actions in that order."
         (if (rigpa--native-p mode)
             (when (> rigpa--current-level 0)
               (rigpa--enter-level (1- rigpa--current-level)))
-          ;; first (low-level) exit the current mode
+          ;; just (low-level) exit the current mode
           (chimera--exit-mode mode))
       (rigpa--enter-appropriate-mode))))
 
@@ -237,7 +237,7 @@ Priority: (1) provided mode if admissible (i.e. present in tower) [TODO]
             (when (< rigpa--current-level
                      (1- (rigpa-ensemble-size (rigpa--local-tower))))
               (rigpa--enter-level (1+ rigpa--current-level)))
-          ;; first (low-level) exit the current mode
+          ;; just (low-level) exit the current mode
           (chimera--exit-mode mode))
       (rigpa--enter-appropriate-mode))))
 

--- a/rigpa-tower-mode.el
+++ b/rigpa-tower-mode.el
@@ -93,10 +93,10 @@
          (ground-recall (with-current-buffer ground-buffer
                           rigpa-recall))
          (level (or (rigpa-ensemble-member-position-by-name tower
-                                                          ground-mode-name)
+                                                            ground-mode-name)
                     (and ground-recall
                          (rigpa-ensemble-member-position-by-name tower
-                                                               ground-recall))
+                                                                 ground-recall))
                     0))
          (tower-height (rigpa-ensemble-size tower)))
     (evil-goto-line (- tower-height level))))

--- a/rigpa-types.el
+++ b/rigpa-types.el
@@ -53,6 +53,13 @@ entity, such as modes, towers or complexes.")
                          (editing-ensemble-members ensemble))
                 name))
 
+(defun rigpa--member-of-ensemble-p (ensemble entity-name)
+  "A predicate asserting whether ENTITY-NAME is a member of ENSEMBLE."
+  (not
+   (not
+    (rigpa-ensemble-member-position-by-name ensemble
+                                            entity-name))))
+
 (defun rigpa-ensemble-size (ensemble)
   "Size of ensemble (e.g. height of a tower)."
   (length (editing-ensemble-members ensemble)))
@@ -60,10 +67,6 @@ entity, such as modes, towers or complexes.")
 (defun rigpa-ensemble-member-at-position (tower position)
   "Mode at LEVEL in the TOWER."
   (nth position (editing-ensemble-members tower)))
-
-(defun rigpa--member-of-ensemble-p (entity ensemble)
-  "A predicate asserting whether ENTITY is a member of ENSEMBLE."
-  (memq entity (editing-ensemble-members ensemble)))
 
 
 (provide 'rigpa-types)

--- a/rigpa-types.el
+++ b/rigpa-types.el
@@ -28,6 +28,7 @@
 
 (require 'cl-lib)
 (require 'chimera)
+(require 'dynaring)
 
 (cl-defstruct editing-ensemble
   "Specification for an editing ensemble."
@@ -48,7 +49,7 @@ entity, such as modes, towers or complexes.")
 
 (defun rigpa-ensemble-member-position-by-name (ensemble name)
   "The position of a member in an ensemble, by name."
-  (seq-position (seq-map #'rigpa-editing-entity-name
+  (seq-position (seq-map (lambda (m) (rigpa-editing-entity-name (if (dynaringp m) (dynaring-value m) m)))
                          (editing-ensemble-members ensemble))
                 name))
 

--- a/rigpa-types.el
+++ b/rigpa-types.el
@@ -47,11 +47,37 @@ entity, such as modes, towers or complexes.")
 (cl-defmethod rigpa-editing-entity-name ((entity editing-ensemble))
   (editing-ensemble-name entity))
 
+(defun rigpa--position-in-mode-list (modelist name)
+  "Position of NAME in MODELIST.
+
+Having lifted each mode into a list if it isn't already a list of
+modes (the latter derived from a mode ring), we simply check if NAME
+is a member of any of these lists of modes, returning the index of the
+first mode list (corresponding to a level, typically) where that's
+true.
+
+This is just a quick hack in order to support levels being mode rings
+and not just modes. One potentially better approach would be for
+levels to *always* be mode rings, even if of size one."
+  (when modelist
+    (let ((ms (car modelist))
+          (modelist (cdr modelist)))
+      (if (member name ms)
+          0
+        (let ((result (rigpa--position-in-mode-list modelist
+                                                    name)))
+          (when result
+            (1+ result)))))))
+
 (defun rigpa-ensemble-member-position-by-name (ensemble name)
   "The position of a member in an ensemble, by name."
-  (seq-position (seq-map (lambda (m) (rigpa-editing-entity-name (if (dynaringp m) (dynaring-value m) m)))
-                         (editing-ensemble-members ensemble))
-                name))
+  (rigpa--position-in-mode-list (seq-map (lambda (m)
+                                           (seq-map #'rigpa-editing-entity-name
+                                                    (if (dynaringp m)
+                                                        (dynaring-values m)
+                                                      (list m))))
+                                         (editing-ensemble-members ensemble))
+                                name))
 
 (defun rigpa--member-of-ensemble-p (ensemble entity-name)
   "A predicate asserting whether ENTITY-NAME is a member of ENSEMBLE."

--- a/rigpa.el
+++ b/rigpa.el
@@ -78,12 +78,16 @@
 (define-derived-mode rigpa-meta-mode
   text-mode "Meta"
   "Major mode for meta modes"
-  (define-key rigpa-meta-mode-map (kbd "g r") 'rigpa--reload-tower))
+  (define-key rigpa-meta-mode-map
+              (kbd "g r")
+              'rigpa--reload-tower))
 
 (define-derived-mode rigpa-meta-tower-mode
   text-mode "Tower"
   "Major mode for meta modes"
-  (define-key rigpa-meta-tower-mode-map (kbd "g r") 'rigpa--reload-tower))
+  (define-key rigpa-meta-tower-mode-map
+              (kbd "g r")
+              'rigpa--reload-tower))
 
 ;; wrap native evil states in chimera modes
 (defvar chimera-normal-mode-entry-hook nil
@@ -225,35 +229,49 @@
                    (intern
                     (concat "evil-" state "-state-map")))))
       (if (member state chimera-insertion-states)
-          (define-key keymap [escape] #'rigpa-enter-higher-level)
-        (define-key keymap [escape] (lambda ()
-                                      (interactive)
-                                      (if (equal "lisp"
-                                                 (rigpa-editing-entity-name
-                                                  (rigpa--local-tower)))
-                                          (rigpa-rotate-mode-ring-left)
-                                        (rigpa-enter-higher-level))))
-        (define-key keymap [return] #'rigpa--enter-lower-or-pass-through))))
+          (define-key keymap
+                      [escape]
+                      #'rigpa-enter-higher-level)
+        (define-key keymap
+                    [escape]
+                    (lambda ()
+                      (interactive)
+                      (if (equal "lisp"
+                                 (rigpa-editing-entity-name
+                                  (rigpa--local-tower)))
+                          (rigpa-rotate-mode-ring-left)
+                        (rigpa-enter-higher-level))))
+        (define-key keymap
+                    [return]
+                    #'rigpa--enter-lower-or-pass-through))))
   ;; exit visual state gracefully
-  (define-key evil-visual-state-map [escape] (lambda ()
-                                               (interactive)
-                                               (evil-exit-visual-state)
-                                               (rigpa-enter-higher-level)))
-  (define-key evil-visual-state-map [return] (lambda ()
-                                               (interactive)
-                                               (evil-exit-visual-state)
-                                               (rigpa-enter-lower-level)))
+  (define-key evil-visual-state-map
+              [escape]
+              (lambda ()
+                (interactive)
+                (evil-exit-visual-state)
+                (rigpa-enter-higher-level)))
+  (define-key evil-visual-state-map
+              [return]
+              (lambda ()
+                (interactive)
+                (evil-exit-visual-state)
+                (rigpa-enter-lower-level)))
   ;; interrupting operator state should unconditionally "escape"
   ;; but by default an operator enters insert state as a follow-on.
   ;; we use the default normal override binding here to avoid this.
   ;; This will bypass any rigpa-specific behavior, but as it seems
   ;; unlikely that we'd want to incorporate operator state formally
   ;; as part of any structures, this seems a reasonable hack
-  (define-key evil-operator-state-map [escape] #'evil-force-normal-state)
+  (define-key evil-operator-state-map
+              [escape]
+              #'evil-force-normal-state)
   ;; same, I guess, for replace state? though, why are we even overriding
   ;; [esc] above to begin with? Should we not integrate built-in evil
   ;; states other than Normal?
-  (define-key evil-replace-state-map [escape] #'evil-force-normal-state))
+  (define-key evil-replace-state-map
+              [escape]
+              #'evil-force-normal-state))
 
 (defun rigpa--register-local-mode (mode)
   "Register the local mode MODE."

--- a/rigpa.el
+++ b/rigpa.el
@@ -224,8 +224,9 @@
     (let ((keymap (symbol-value
                    (intern
                     (concat "evil-" state "-state-map")))))
-      (define-key keymap [escape] #'rigpa-enter-higher-level)
-      (unless (member state chimera-insertion-states)
+      (if (member state chimera-insertion-states)
+          (define-key keymap [escape] #'rigpa-enter-higher-level)
+        (define-key keymap [escape] #'rigpa-rotate-mode-ring-left)
         (define-key keymap [return] #'rigpa--enter-lower-or-pass-through))))
   ;; exit visual state gracefully
   (define-key evil-visual-state-map [escape] (lambda ()

--- a/rigpa.el
+++ b/rigpa.el
@@ -236,11 +236,7 @@
                     [escape]
                     (lambda ()
                       (interactive)
-                      (if (equal "lisp"
-                                 (rigpa-editing-entity-name
-                                  (rigpa--local-tower)))
-                          (rigpa-rotate-mode-ring-left)
-                        (rigpa-enter-higher-level))))
+                      (rigpa-enter-higher-level)))
         (define-key keymap
                     [return]
                     #'rigpa--enter-lower-or-pass-through))))

--- a/rigpa.el
+++ b/rigpa.el
@@ -226,7 +226,13 @@
                     (concat "evil-" state "-state-map")))))
       (if (member state chimera-insertion-states)
           (define-key keymap [escape] #'rigpa-enter-higher-level)
-        (define-key keymap [escape] #'rigpa-rotate-mode-ring-left)
+        (define-key keymap [escape] (lambda ()
+                                      (interactive)
+                                      (if (equal "lisp"
+                                                 (rigpa-editing-entity-name
+                                                  (rigpa--local-tower)))
+                                          (rigpa-rotate-mode-ring-left)
+                                        (rigpa-enter-higher-level))))
         (define-key keymap [return] #'rigpa--enter-lower-or-pass-through))))
   ;; exit visual state gracefully
   (define-key evil-visual-state-map [escape] (lambda ()


### PR DESCRIPTION
### Summary of Changes

Instead of towers containing modes, we'd like them to contain mode rings. This is a natural and intuitive structure to use for modes and can make things pretty nice.

This uses the [dynaring](https://github.com/countvajhula/dynaring) package.

The goals of this PR are:

- Currently, tower "levels" contain modes. Change this so that they contain mode rings (which could have a single element).
- Define a default UX in terms of keybinding flows, maybe something like [what Tommy uses](https://github.com/drym-org/symex.el/issues/24#issuecomment-815110143).
- Define a visual (and textual) representation of a mode ring which can be appropriately edited in meta modes.
- Review all instances of "escaping" and "entering" which assume a tower topology, and see if they should use ring rotation instead.
- Review and update the default editing structures to make appropriate use of rings (the towers including lisp tower, the complexes, as well as the structures used in meta modes).
- Review interop in Symex to see if those need to be changed (e.g. to use rings instead of escaping higher).
- Document the various structures that may be relevant for users, and how to define keybindings for them to support whatever UX/topology they want.
- Document the required `.emacs.d` config updates.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
